### PR TITLE
Add subfinder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,10 @@ ENV PATH="${PATH}:${GOROOT}/bin"
 ENV PATH="${PATH}:${GOPATH}/bin"
 ENV GOPATH=$HOME/go
 
+ENV HOME="/tmp"
+RUN mkdir "/tmp/.config"
+RUN chmod -R a+rwx "/tmp"
+
 RUN go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
 
 RUN go install github.com/d3mondev/puredns/v2@latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,8 @@ ENV PATH="${PATH}:${GOROOT}/bin"
 ENV PATH="${PATH}:${GOPATH}/bin"
 ENV GOPATH=$HOME/go
 
+RUN go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
+
 RUN go install github.com/d3mondev/puredns/v2@latest
 
 RUN go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest


### PR DESCRIPTION
Hi,

To execute subfinder, we require a "$HOME/.config/" directory. Creating "/home/sbx_user1051/.config/" does not help since this filesystem becomes read-only once the lambda is started. Only "/tmp" is writable in AWS lambdas.

Finally, the chmod command is necessary because the "/tmp/.config" directory is created as root. Using chown is not possible, as it would break multi-cloud compatibility, since the end user is surely not the same on AWS, Google, and Azure.

Once your image is deployed, you can test subfinder using the command below:

python shadowclone.py -i domains.txt -s 3 -c "/go/bin/subfinder -dL {INPUT}" -o subf.txt

![Screenshot_2023-06-28_23-27-10](https://github.com/fyoorer/ShadowClone/assets/123511531/827aa168-d32e-474e-a049-35bd472d574a)

PS : I tested this configuration using python 3.11.