### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,10 +63,11 @@ RUN unzip lithops_lambda.zip \
 
 
 # install go
-RUN wget https://dl.google.com/go/go1.20.5.linux-amd64.tar.gz
-RUN tar -xvf go1.20.5.linux-amd64.tar.gz
-RUN rm go1.20.5.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.22.3.linux-amd64.tar.gz
+RUN tar -xvf go1.22.3.linux-amd64.tar.gz
+RUN rm go1.22.3.linux-amd64.tar.gz
 RUN mv go /usr/local
+
 
 # ENV for Go
 ENV GOROOT="/usr/local/go"


### PR DESCRIPTION
Install latest version of go instead of the mentioned one

abone installing today with the mentioned Dockerfile. The app through this error when it reaches ```subfinder``` install command: 

```
10.89 /go/pkg/mod/github.com/projectdiscovery/utils@v0.1.0/errkit/errors.go:9:2: package log/slog is not in GOROOT (/usr/local/go/src/log/slog)
10.89 note: imported by a module that requires go 1.21
10.89 /go/pkg/mod/github.com/projectdiscovery/httpx@v1.6.3/common/httpx/title.go:12:2: package slices is not in GOROOT (/usr/local/go/src/slices)
10.89 note: imported by a module that requires go 1.21

```

As can be seen, the latest version of Subfinder and possibly other projectdiscovery tools requires Go 1.21 or above. 
