### PR TITLE
add pytest to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,3 +71,4 @@ wrapt
 delegator.py
 pickledb
 invoke
+pytest


### PR DESCRIPTION
### Description
When running `lithops test`, lack of pytest caused it to fail.

### Error
Traceback (most recent call last):
  File "/home/user/Documents/ShadowClone/env/bin/lithops", line 8, in <module>
    sys.exit(lithops_cli())
  File "/home/user/Documents/ShadowClone/env/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/user/Documents/ShadowClone/env/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/user/Documents/ShadowClone/env/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/user/Documents/ShadowClone/env/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/user/Documents/ShadowClone/env/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/user/Documents/ShadowClone/env/lib/python3.10/site-packages/lithops/scripts/cli.py", line 156, in test
    import pytest
ModuleNotFoundError: No module named 'pytest'

### Ubuntu version tested on:
PRETTY_NAME="Ubuntu 22.04.5 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.5 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy

### Reproducing
Run the commands here on a fresh OS: https://github.com/fyoorer/ShadowClone/wiki#local-machine

### Fix:
Add pytest to requirements.txt or manually run `pip install pytest` on the directory before running lithops test.